### PR TITLE
adding acceleration pseudo velocity shock spectrum (APVSS)

### DIFF
--- a/endaq/calc/shock.py
+++ b/endaq/calc/shock.py
@@ -67,7 +67,7 @@ def pseudo_velocity(
     damp: float = 0,
     two_sided: bool = False,
     aggregate_axes: bool = False,
-    use_rel_accel=True,
+    use_abs_accel=True,
 ) -> pd.DataFrame:
     """The pseudo velocity of an acceleration signal."""
     if two_sided and aggregate_axes:
@@ -82,7 +82,7 @@ def pseudo_velocity(
         dtype=np.float64,
     )
 
-    if use_rel_accel:
+    if use_abs_accel:
         for i_nd in np.ndindex(freqs.shape):
             rd = abs_accel(df, omega[i_nd], damp).to_numpy()
             if aggregate_axes:

--- a/endaq/calc/shock.py
+++ b/endaq/calc/shock.py
@@ -40,18 +40,18 @@ def rel_displ(df: pd.DataFrame, omega: float, damp: float = 0) -> pd.DataFrame:
     )
 
 
-def rel_accel(df: pd.DataFrame, omega: float, damp: float = 0) -> pd.DataFrame:
-    """Calculate the relative acceleration for a SDOF system."""
+def abs_accel(df: pd.DataFrame, omega: float, damp: float = 0) -> pd.DataFrame:
+    """Calculate the absolute acceleration for a SDOF system."""
     # Generate the transfer function
-    #   H(s) = L{z"(t)}(s) / L{y"(t)}(s) = Z(s)/Y(s)
+    #   H(s) = L{x"(t)}(s) / L{y"(t)}(s) = X(s)/Y(s)
     # for the PDE
-    #   z" + (2ζω)z' + (ω^2)z = -y"
+    #   x" + (2ζω)x' + (ω^2)x = (2ζω)y' + (ω^2)y
     dt = (df.index[-1] - df.index[0]) / (len(df.index) - 1)
     if isinstance(dt, (np.timedelta64, pd.Timedelta)):
         dt = dt / np.timedelta64(1, "s")
 
     tf = scipy.signal.TransferFunction(
-        [-1, 0, 0],
+        [0, 2 * damp * omega, omega ** 2],
         [1, 2 * damp * omega, omega ** 2],
     ).to_discrete(dt=dt)
 
@@ -84,7 +84,7 @@ def pseudo_velocity(
 
     if use_rel_accel:
         for i_nd in np.ndindex(freqs.shape):
-            rd = rel_accel(df, omega[i_nd], damp).to_numpy()
+            rd = abs_accel(df, omega[i_nd], damp).to_numpy()
             if aggregate_axes:
                 rd = L2_norm(rd, axis=-1, keepdims=True)
 


### PR DESCRIPTION
resolves #31

An SDOF system defines the following relationship between an input acceleration <img src="https://render.githubusercontent.com/render/math?math=y(t)"> and the *relative* acceleration of a SDOF mass <img src="https://render.githubusercontent.com/render/math?math=z_\omega (t)">:

<img src="https://render.githubusercontent.com/render/math?math=-y'' = z'' + 2\zeta z' + \omega^2 z">

The "traditional" definition of the PVSS calculates <img src="https://render.githubusercontent.com/render/math?math=\omega \max_t \left|z_\omega(t)\right|">; however, some prefer to calculate the APVSS, which is defined as <img src="https://render.githubusercontent.com/render/math?math=\frac1\omega \max_t \left|x_\omega''(t)\right|">.

Thus this PR aims to add the APVSS to the `endaq.calc.shock` module.

*Edit - updated the APVSS definition to use the absolute acceleration x*