### PR TITLE
Feature/pvss resultant

### DIFF
--- a/endaq/calc/shock.py
+++ b/endaq/calc/shock.py
@@ -46,6 +46,8 @@ def pseudo_velocity(
     aggregate_axes: bool = False,
 ) -> pd.DataFrame:
     """The pseudo velocity of an acceleration signal."""
+    if two_sided and aggregate_axes:
+        raise ValueError("cannot enable both options `two_sided` and `aggregate_axes`")
     freqs = np.asarray(freqs)
     if freqs.ndim != 1:
         raise ValueError("target frequencies must be in a 1D-array")

--- a/tests/calc/test_shock.py
+++ b/tests/calc/test_shock.py
@@ -68,11 +68,19 @@ def test_rel_displ(freq, damp):
     freq=hyp_st.floats(1, 20),
     damp=hyp_st.floats(0, 1, exclude_max=True),
     factor=hyp_st.floats(-1e2, 1e2),
+    aggregate_axes=hyp_st.booleans(),
 )
-def test_pseudo_velocity_linearity(df_accel, freq, damp, factor):
+def test_pseudo_velocity_linearity(df_accel, freq, damp, factor, aggregate_axes):
     pd.testing.assert_frame_equal(
-        shock.pseudo_velocity(factor * df_accel, [freq], damp=damp),
-        (factor * shock.pseudo_velocity(df_accel, [freq], damp=damp)).abs(),
+        shock.pseudo_velocity(
+            factor * df_accel, [freq], damp=damp, aggregate_axes=aggregate_axes
+        ),
+        (
+            factor
+            * shock.pseudo_velocity(
+                df_accel, [freq], damp=damp, aggregate_axes=aggregate_axes
+            )
+        ).abs(),
     )
 
 

--- a/tests/calc/test_shock.py
+++ b/tests/calc/test_shock.py
@@ -62,7 +62,7 @@ def test_rel_displ(freq, damp):
 @hyp.given(
     df_accel=hyp_np.arrays(
         dtype=np.float64,
-        shape=(40,),
+        shape=(40, 2),
         elements=hyp_st.floats(1e-20, 1e20),
     ).map(lambda array: pd.DataFrame(array, index=np.arange(40) * 1e-4)),
     freq=hyp_st.floats(1, 20),
@@ -79,7 +79,7 @@ def test_pseudo_velocity_linearity(df_accel, freq, damp, factor):
 @hyp.given(
     df_pvss=hyp_np.arrays(
         dtype=np.float64,
-        shape=(40,),
+        shape=(40, 2),
         elements=hyp_st.floats(1e-20, 1e20),
     ).map(lambda array: pd.DataFrame(array, index=np.arange(1, 41))),
     damp=hyp_st.floats(0, 0.2),


### PR DESCRIPTION
This PR provides the PVSS function with a parameter `aggregate_axes`, which will compute the resultant PVSS among each column of the dataframe. (Unlike other computations like the PSD, the PVSS resultant can *NOT* be correctly calculated after-the-fact from the PVSS of each axis; hence the need for this parameter.)