### PR TITLE
Fix/dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 
 INSTALL_REQUIRES = [
     "numpy<=1.18",
-    "pandas<=1.1",
+    "pandas<=1.2",
     "scipy<=1.6",
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
 
 INSTALL_REQUIRES = [
-    "numpy<=1.18",
-    "pandas<=1.2",
-    "scipy<=1.6",
+    "numpy>=1.18",
+    "pandas>=1.2",
+    "scipy>=1.6",
     ]
 
 TEST_REQUIRES = [

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
 
 INSTALL_REQUIRES = [
-    "numpy>=1.17",
-    "pandas>=1.1",
-    "scipy>=1.6",
+    "numpy<=1.18",
+    "pandas<=1.1",
+    "scipy<=1.6",
     ]
 
 TEST_REQUIRES = [

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 INSTALL_REQUIRES = [
     "numpy<=1.17",
     "pandas<=1.1",
-    "scipy<=1.2",
+    "scipy<=1.6",
     ]
 
 TEST_REQUIRES = [

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
 
 INSTALL_REQUIRES = [
-    "numpy",
-    "pandas",
-    "scipy",
+    "numpy<=1.17",
+    "pandas<=1.1",
+    "scipy<=1.2",
     ]
 
 TEST_REQUIRES = [

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
 
 INSTALL_REQUIRES = [
-    "numpy<=1.17",
-    "pandas<=1.1",
-    "scipy<=1.6",
+    "numpy>=1.17",
+    "pandas>=1.1",
+    "scipy>=1.6",
     ]
 
 TEST_REQUIRES = [


### PR DESCRIPTION
This PR adjusts the project's installation dependencies to exclude version of e.g., numpy, scipy, pandas, that do not support all the requisite features for this project.

This should make `pip`-installs on machines with default installations of numpy/scipy/pandas (e.g., Colab) less error-prone.