### PR TITLE
Fix/butterworth

### DIFF
--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Optional, Union, Tuple
 
-import numpy as np
 import pandas as pd
 import scipy.signal
 

--- a/endaq/calc/filters.py
+++ b/endaq/calc/filters.py
@@ -60,16 +60,6 @@ def butterworth(
         fs=1 / dt,
         output="sos",
     )
+    array = scipy.signal.sosfiltfilt(sos_coeffs, df.to_numpy(), axis=0)
 
-    array = df.to_numpy()
-
-    for b, a in zip(*np.split(sos_coeffs, [3], axis=-1)):
-        array = scipy.signal.filtfilt(
-            b, a, array, axis=0, method="gust", irlen=5 * 10 ** 4
-        )
-
-    return pd.DataFrame(
-        array,
-        index=df.index,
-        columns=df.columns,
-    )
+    return pd.DataFrame(array, index=df.index, columns=df.columns)


### PR DESCRIPTION
This PR removes the Gustaffson's initial conditions method from the `butterworth`'s biquad implementation. Since the "good-ness" of the function is hard to quantify, I've copied below a Jupyter Notebook which has both versions of the routine loaded, so that you can manually test the changes beforehand: https://colab.research.google.com/drive/1PsSwq2Q0BEUTbRemo9eVxKq0Dnty366C?usp=sharing