### PR TITLE
Fix/to jagged

### DIFF
--- a/endaq/calc/psd.py
+++ b/endaq/calc/psd.py
@@ -128,7 +128,7 @@ def to_jagged(
     freq_splits = np.asarray(freq_splits)
     if len(freq_splits) < 2:
         raise ValueError("need at least two frequency bounds")
-    if not np.all(np.diff(freq_splits) > 0):
+    if not np.all(freq_splits[:-1] <= freq_splits[1:]):
         raise ValueError("frequency bounds must be strictly increasing")
 
     # Check that PSD samples do not skip any frequency bins

--- a/endaq/calc/psd.py
+++ b/endaq/calc/psd.py
@@ -126,8 +126,10 @@ def to_jagged(
     :return: a periodogram with the given frequency spacing
     """
     freq_splits = np.asarray(freq_splits)
-    if not np.all(np.diff(freq_splits, prepend=0) > 0):
-        raise ValueError
+    if len(freq_splits) < 2:
+        raise ValueError("need at least two frequency bounds")
+    if not np.all(np.diff(freq_splits) > 0):
+        raise ValueError("frequency bounds must be strictly increasing")
 
     # Check that PSD samples do not skip any frequency bins
     spacing_test = np.diff(np.searchsorted(freq_splits, df.index))

--- a/endaq/calc/psd.py
+++ b/endaq/calc/psd.py
@@ -133,7 +133,7 @@ def to_jagged(
 
     # Check that PSD samples do not skip any frequency bins
     spacing_test = np.diff(np.searchsorted(freq_splits, df.index))
-    if np.any(spacing_test > 1):
+    if np.any(spacing_test < 1):
         warnings.warn(
             "empty frequency bins in re-binned PSD; "
             "original PSD's frequency spacing is too coarse",


### PR DESCRIPTION
This addresses some value-error problems, as shown in the below example:

### Code
```python
freq_bins=np.array([0.0,65,300,10000])
rms_bins = endaq.calc.psd.to_jagged(psd*(psd.index[1]), freq_splits=freq_bins, agg='sum')
```

### Error
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-40-f735a037c65e> in <module>()
      1 freq_bins=np.array([0.0,65,300,10000])
----> 2 rms_bins = endaq.calc.psd.to_jagged(psd*(psd.index[1]), freq_splits=freq_bins, agg='sum')

/usr/local/lib/python3.7/dist-packages/endaq/calc/psd.py in to_jagged(df, freq_splits, agg)
    109     freq_splits = np.asarray(freq_splits)
    110     if not np.all(np.diff(freq_splits, prepend=0) > 0):
--> 111         raise ValueError
    112 
    113     # Check that PSD samples do not skip any frequency bins

ValueError: 
```