### PR TITLE
Feature/psd scaling

### DIFF
--- a/endaq/calc/psd.py
+++ b/endaq/calc/psd.py
@@ -78,7 +78,8 @@ def welch(
     :param scaling: the scaling of the output; `"density"` & `"spectrum"`
         correspond to the same options in `scipy.signal.welch`; `"parseval"`
         will maintain the "energy" between the input & output, s.t.
-        `welch(df, scaling="parseval") - df.pow(2).sum()` is minimized
+        `welch(df, scaling="parseval").sum(axis="rows")` is roughly equal to
+        `df.abs().pow(2).sum(axis="rows")`
     :param kwargs: other parameters to pass directly to `scipy.signal.welch`
     :return: a periodogram
 

--- a/endaq/calc/psd.py
+++ b/endaq/calc/psd.py
@@ -75,6 +75,10 @@ def welch(
     :param df: the input data
     :param bin_width: the desired width of the resulting frequency bins, in Hz;
         defaults to 1 Hz
+    :param scaling: the scaling of the output; `"density"` & `"spectrum"`
+        correspond to the same options in `scipy.signal.welch`; `"parseval"`
+        will maintain the "energy" between the input & output, s.t.
+        `welch(df, scaling="parseval") - df.pow(2).sum()` is minimized
     :param kwargs: other parameters to pass directly to `scipy.signal.welch`
     :return: a periodogram
 

--- a/endaq/calc/psd.py
+++ b/endaq/calc/psd.py
@@ -87,6 +87,10 @@ def welch(
 
         `SciPy Welch's method <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.welch.html>`_
         Documentation for the periodogram function wrapped internally.
+
+        `Parseval's Theorem <https://en.wikipedia.org/wiki/Parseval's_theorem>_`
+        - the theorem relating the RMS of a time-domain signal to that of its
+        frequency spectrum
     """
     dt = utils.sample_spacing(df)
     fs = 1 / dt

--- a/endaq/calc/psd.py
+++ b/endaq/calc/psd.py
@@ -94,13 +94,12 @@ def welch(
     freqs, psd = scipy.signal.welch(
         df.values, fs=fs, nperseg=int(fs / bin_width), **kwargs, axis=0
     )
-    result = pd.DataFrame(
+    if scaling == "parseval":
+        psd = psd * freqs[1]
+
+    return pd.DataFrame(
         psd, index=pd.Series(freqs, name="frequency (Hz)"), columns=df.columns
     )
-
-    if scaling == "parseval":
-        result = result * freqs[1]
-    return result
 
 
 def differentiate(df: pd.DataFrame, n: float = 1) -> pd.DataFrame:

--- a/tests/calc/test_psd.py
+++ b/tests/calc/test_psd.py
@@ -16,7 +16,12 @@ from endaq.calc import psd, stats
     df=hyp_np.arrays(
         dtype=np.float64,
         shape=(200,),
-        elements=hyp_st.floats(-1e7, 1e7),
+        elements=hyp_st.floats(
+            # leave at least half the bits of precision (52 / 2) in the
+            # mean-subtracted result
+            1,
+            1e26,
+        ),
     )
     .map(
         lambda array: (array - array.mean(keepdims=True))

--- a/tests/calc/test_psd.py
+++ b/tests/calc/test_psd.py
@@ -9,7 +9,49 @@ import hypothesis.extra.numpy as hyp_np
 import numpy as np
 import pandas as pd
 
-from endaq.calc import psd
+from endaq.calc import psd, stats
+
+
+@hyp.given(
+    df=hyp_np.arrays(
+        dtype=np.float64,
+        shape=(200,),
+        elements=hyp_st.floats(-1e7, 1e7),
+    )
+    .map(
+        lambda array: (array - array.mean(keepdims=True))
+        # V this pushes the zero-mean'd values away from zero
+        * 2 ** (np.finfo(np.float64).minexp // 2)
+    )
+    .map(lambda array: pd.DataFrame(array, index=np.arange(len(array)) * 1e-1)),
+)
+def test_welch_parseval(df):
+    """
+    Test to confirm that `scaling="parseval"` maintains consistency with the
+    time-domain RMS.
+    """
+    df_psd = psd.welch(df, bin_width=1, scaling="parseval")
+    assert df_psd.to_numpy().sum() ** 0.5 == pytest.approx(stats.rms(df.to_numpy()))
+
+
+@pytest.mark.parametrize(
+    "agg1, agg2",
+    [
+        ("mean", lambda x, axis=-1: np.nan_to_num(np.mean(x, axis=axis))),
+        ("sum", np.sum),
+    ],
+)
+def test_to_jagged_modes(psd_df, freq_splits, agg1, agg2):
+    """Test `to_jagged(..., mode='mean')` against the equivalent `mode=np.mean`."""
+    result1 = psd.to_jagged(psd_df, freq_splits, agg=agg1)
+    result2 = psd.to_jagged(psd_df, freq_splits, agg=agg2)
+
+    assert np.all(result1.index == result2.index)
+    np.testing.assert_allclose(
+        result1.to_numpy(),
+        result2.to_numpy(),
+        atol=psd_df.min().min() * 1e-7,
+    )
 
 
 @hyp.given(

--- a/tests/calc/test_psd.py
+++ b/tests/calc/test_psd.py
@@ -31,7 +31,7 @@ def test_welch_parseval(df):
     time-domain RMS.
     """
     df_psd = psd.welch(df, bin_width=1, scaling="parseval")
-    assert df_psd.to_numpy().sum() ** 0.5 == pytest.approx(stats.rms(df.to_numpy()))
+    assert df_psd.to_numpy().sum() == pytest.approx(stats.rms(df.to_numpy()) ** 2)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds an additional scaling option, `scaling="parseval"`, s.t. the root-sum of the resulting frequency spectrum corresponds to the time-domain RMS of the original input signal (as demonstrated in the additional test included herein).

Additional resources:
- a Colab demonstrating the correspondence between the time-domain RMS and the PSD sum: https://colab.research.google.com/drive/1vY0-QquOkb-T02TF3GsAHw5MxfXPw3Pn#scrollTo=pQv9RTH-cJeA
- the `scipy.signal.welch` source re: scaling: https://github.com/scipy/scipy/blob/47bb6febaa10658c72962b9615d5d5aa2513fa3a/scipy/signal/spectral.py#L1803